### PR TITLE
Fix CI/CD issues: coverage, flake8, mypy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,6 +106,7 @@ markers = [
 [tool.coverage.run]
 source = ["src"]
 branch = true
+relative_files = true
 omit = [
     "*/tests/*",
     "*/test_*",

--- a/src/database/base.py
+++ b/src/database/base.py
@@ -64,7 +64,7 @@ class Base(DeclarativeBase):
             repr(user)  # "User(id=1, username='john')"
         """
         # Get primary key columns
-        pk_columns = [col.name for col in self.__table__.primary_key.columns]
+        pk_columns = [col.name for col in self.__table__.primary_key.columns]  # type: ignore
 
         # Build key=value pairs for primary keys
         pk_values = []

--- a/src/database/connection.py
+++ b/src/database/connection.py
@@ -13,7 +13,7 @@ Environment Variables:
 """
 
 import os
-from typing import Generator
+from typing import Any, Generator
 
 from sqlalchemy import create_engine, event
 from sqlalchemy.engine import Engine
@@ -44,14 +44,14 @@ engine = create_engine(
 
 # Enable connection pool statistics logging
 @event.listens_for(Engine, "connect")
-def receive_connect(dbapi_conn, connection_record):
+def receive_connect(dbapi_conn: Any, connection_record: Any) -> None:
     """Log database connections for monitoring."""
     # This can be extended with logging if needed
     pass
 
 
 @event.listens_for(Engine, "checkout")
-def receive_checkout(dbapi_conn, connection_record, connection_proxy):
+def receive_checkout(dbapi_conn: Any, connection_record: Any, connection_proxy: Any) -> None:
     """Track connection checkout for debugging pool exhaustion."""
     # This can be extended with logging/metrics if needed
     pass
@@ -156,8 +156,8 @@ def get_db_info() -> dict:
         "database": parsed.path.lstrip("/"),
         "host": parsed.hostname,
         "port": parsed.port,
-        "pool_size": pool.size(),
-        "checked_out_connections": pool.checkedout(),
-        "overflow": pool.overflow(),
-        "pool_timeout": pool._timeout,
+        "pool_size": pool.size(),  # type: ignore
+        "checked_out_connections": pool.checkedout(),  # type: ignore
+        "overflow": pool.overflow(),  # type: ignore
+        "pool_timeout": pool._timeout,  # type: ignore
     }

--- a/src/database/models/conversation.py
+++ b/src/database/models/conversation.py
@@ -11,7 +11,7 @@ import uuid
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
-from sqlalchemy import JSON, ForeignKey, String, UniqueConstraint
+from sqlalchemy import JSON, ForeignKey, UniqueConstraint
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.dialects.postgresql import UUID as SQLUUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship

--- a/src/database/models/document.py
+++ b/src/database/models/document.py
@@ -275,4 +275,7 @@ class Document(Base, TimestampMixin):
 
     def __repr__(self) -> str:
         """String representation showing title and type."""
-        return f"Document(id={self.id}, title='{self.title}', type='{self.document_type}', status='{self.status}')"
+        return (
+            f"Document(id={self.id}, title='{self.title}', "
+            f"type='{self.document_type}', status='{self.status}')"
+        )

--- a/src/database/models/document_embedding.py
+++ b/src/database/models/document_embedding.py
@@ -11,8 +11,8 @@ Stores vector embeddings for RAG-powered context retrieval:
 import uuid
 from typing import TYPE_CHECKING, Any, Dict, Optional
 
-from pgvector.sqlalchemy import Vector
-from sqlalchemy import JSON, CheckConstraint, ForeignKey, Integer, String, Text, UniqueConstraint
+from pgvector.sqlalchemy import Vector  # type: ignore
+from sqlalchemy import JSON, CheckConstraint, ForeignKey, Integer, Text, UniqueConstraint
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.dialects.postgresql import UUID as SQLUUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship, validates

--- a/src/database/models/document_type.py
+++ b/src/database/models/document_type.py
@@ -220,4 +220,7 @@ class DocumentType(Base, TimestampMixin):
 
     def __repr__(self) -> str:
         """String representation showing type name and step count."""
-        return f"DocumentType(id={self.id}, type_name='{self.type_name}', steps={self.workflow_step_count})"
+        return (
+            f"DocumentType(id={self.id}, type_name='{self.type_name}', "
+            f"steps={self.workflow_step_count})"
+        )

--- a/src/database/models/document_version.py
+++ b/src/database/models/document_version.py
@@ -11,7 +11,7 @@ import uuid
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Dict, Optional
 
-from sqlalchemy import JSON, CheckConstraint, ForeignKey, Integer, String, Text, UniqueConstraint
+from sqlalchemy import JSON, CheckConstraint, ForeignKey, Integer, Text, UniqueConstraint
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.dialects.postgresql import UUID as SQLUUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship, validates

--- a/src/database/models/user.py
+++ b/src/database/models/user.py
@@ -9,7 +9,7 @@ Represents users in the system with different roles:
 """
 
 import uuid
-from typing import TYPE_CHECKING, List
+from typing import TYPE_CHECKING, Any, List
 
 from sqlalchemy import String, event
 from sqlalchemy.dialects.postgresql import UUID as SQLUUID
@@ -126,7 +126,7 @@ class User(Base, TimestampMixin):
 
 # Event listener to ensure email is always lowercase
 @event.listens_for(User.email, "set", retval=True)
-def lowercase_email(target, value, oldvalue, initiator):
+def lowercase_email(target: Any, value: Any, oldvalue: Any, initiator: Any) -> Any:
     """Ensure email is always stored in lowercase."""
     if value is not None:
         return value.lower()

--- a/tests/test_database_base.py
+++ b/tests/test_database_base.py
@@ -10,7 +10,6 @@ Tests:
 
 from datetime import datetime
 
-import pytest
 from sqlalchemy import String
 from sqlalchemy.orm import Mapped, mapped_column
 

--- a/tests/test_models_core.py
+++ b/tests/test_models_core.py
@@ -10,7 +10,6 @@ Tests:
 """
 
 import uuid
-from datetime import datetime
 
 import pytest
 from sqlalchemy import create_engine

--- a/tests/test_models_relationships.py
+++ b/tests/test_models_relationships.py
@@ -10,7 +10,6 @@ Tests:
 """
 
 import uuid
-from datetime import datetime
 
 import pytest
 from sqlalchemy import create_engine


### PR DESCRIPTION
Resolves all GitHub Actions CI failures:

1. Coverage Configuration:
   - Add relative_files = true to [tool.coverage.run]
   - Fixes "Cannot read .coverage files because files are absolute" error

2. Flake8 Linting:
   - Remove unused imports (String from conversation, document_embedding, document_version)
   - Remove unused pytest imports from test files
   - Remove unused datetime imports from test files
   - Fix line length issues in __repr__ methods (document.py, document_type.py)

3. Mypy Type Checking:
   - Add type annotations to event listeners (receive_connect, receive_checkout, lowercase_email)
   - Add type: ignore for pgvector library (missing stubs)
   - Add type: ignore for SQLAlchemy Pool attributes
   - Add type: ignore for primary_key.columns attribute
   - Add Any to typing imports where needed

All checks now pass locally:
- flake8: No issues
- mypy: Success, no issues found in 14 source files
- pytest: 48 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)