### PR TITLE
Hotfix: Fix flake8 errors in US-F1-E5-S3

### DIFF
--- a/src/services/relationship_service.py
+++ b/src/services/relationship_service.py
@@ -735,7 +735,7 @@ class RelationshipService:
         # Build context from root to immediate parent
         context_parts = ["# Parent Context\n"]
 
-        for doc, _, depth in reversed(ancestors):  # Root first
+        for doc, _, _depth in reversed(ancestors):  # Root first
             # Add section for this parent
             context_parts.append(f"## {doc.document_type}: {doc.title}\n")
 

--- a/tests/test_ripple_effect_context.py
+++ b/tests/test_ripple_effect_context.py
@@ -8,7 +8,6 @@ Tests:
 """
 
 import uuid
-from datetime import datetime, timezone
 
 import pytest
 from sqlalchemy import create_engine


### PR DESCRIPTION
## Summary

Quick hotfix to resolve flake8 CI failures after merging PR #44.

## Fixes

1. **B007**: Renamed unused loop variable `depth` to `_depth` in `get_parent_context()`
   - Line 738 in relationship_service.py
   - Variable was extracted but never used in the loop body

2. **F401**: Removed unused `datetime` and `timezone` imports
   - test_ripple_effect_context.py
   - Imports were added but not needed (datetime logic is in the service)

## Test Results

- All 14 tests still passing ✅
- Flake8 passes locally ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)