### PR TITLE
Hotfix: Fix mypy type annotation error in health_check_db

### DIFF
--- a/src/api/main.py
+++ b/src/api/main.py
@@ -1,5 +1,7 @@
 """FastAPI application entry point."""
 
+from typing import Union
+
 from fastapi import FastAPI, Request, status
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
@@ -74,8 +76,8 @@ def health_check() -> dict:
 
 
 # Database health check
-@app.get("/health/db", tags=["health"])
-def health_check_db():
+@app.get("/health/db", tags=["health"], response_model=None)
+def health_check_db() -> Union[dict, JSONResponse]:
     """
     Database health check endpoint.
 


### PR DESCRIPTION
## Problem
CI/CD failed on main with mypy error:
```
src/api/main.py:78: error: Function is missing a return type annotation [no-untyped-def]
```

## Solution
- Added `Union[dict, JSONResponse]` return type annotation to `health_check_db()` function
- Added `response_model=None` to decorator to prevent FastAPI validation error with Union types

## Testing
- ✅ All tests pass locally (16/16)
- ✅ Mypy passes locally with no errors
- ✅ Function correctly returns dict on success, JSONResponse on error

## References
- Resolves CI/CD failure from PR #52
- Related to US-F1-E7-S1: FastAPI Foundation & Health Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)