### PR TITLE
Fix E2E: Correct metadata attribute name in ripple effect test

### DIFF
--- a/tests/e2e/test_e2e_workflows.py
+++ b/tests/e2e/test_e2e_workflows.py
@@ -175,7 +175,7 @@ class TestE2EDocumentHierarchy:
         # Assert: Child document should be marked
         child_doc = test_db.query(Document).filter(Document.id == uuid.UUID(child_id)).first()
         assert child_doc is not None
-        assert child_doc.metadata.get("needs_review") is True
+        assert child_doc.doc_metadata.get("needs_review") is True
 
     def test_e2e_breadcrumb_navigation(self, api_client, test_db):
         """


### PR DESCRIPTION
## Summary

Fixes the last failing E2E test: `test_e2e_ripple_effect_propagation`

**Error:** `AttributeError: 'MetaData' object has no attribute 'get'`

## Root Cause

The test was accessing `child_doc.metadata.get("needs_review")` at line 178, but:
- The Document model field is named **`doc_metadata`**, not `metadata`
- `metadata` is SQLAlchemy's MetaData object (table schema metadata)
- Calling `.get()` on SQLAlchemy's MetaData caused the AttributeError

## Changes

### tests/e2e/test_e2e_workflows.py:178
```python
# BEFORE (wrong):
assert child_doc.metadata.get("needs_review") is True

# AFTER (correct):
assert child_doc.doc_metadata.get("needs_review") is True
```

## Testing

- **Local:** Pre-commit checks passed (black, isort, flake8, mypy)
- **CI/CD:** Should fix the failing test → 9/9 E2E tests passing

## Impact

- Fixes last E2E test failure on main branch
- Should make CI/CD green on main

---

🤖 Fixed by: Claude Code (LLM Agent)

Co-Authored-By: Claude <noreply@anthropic.com>